### PR TITLE
Checking argument counts for callbacks

### DIFF
--- a/src/Handlers/AbstractHandler.php
+++ b/src/Handlers/AbstractHandler.php
@@ -6,6 +6,8 @@ namespace Dashifen\WPHandler\Handlers;
 
 use Closure;
 use ReflectionClass;
+use ReflectionMethod;
+use ReflectionFunction;
 use ReflectionException;
 use Dashifen\WPDebugging\WPDebuggingTrait;
 use Dashifen\WPHandler\Hooks\HookException;
@@ -37,7 +39,7 @@ abstract class AbstractHandler implements HandlerInterface
    * @param HookCollectionFactoryInterface|null $hookCollectionFactory
    */
   public function __construct(
-    ?HookFactoryInterface $hookFactory = null,
+    ?HookFactoryInterface           $hookFactory = null,
     ?HookCollectionFactoryInterface $hookCollectionFactory = null
   ) {
     // likely, the vast majority of situations will not require behaviors other
@@ -99,9 +101,10 @@ abstract class AbstractHandler implements HandlerInterface
       
       foreach ($this->hookCollection as $hook) {
         if ($hook->method === $method) {
+          
           // well, we just found a hook using this method, so the problem
           // must be that we're at the wrong action or priority.  let's see
-          // if which it is.
+          // which it is.
           
           if ($hook->hook !== $action) {
             throw new HandlerException(
@@ -265,7 +268,7 @@ abstract class AbstractHandler implements HandlerInterface
     // it's internal array.  then, we just call their initialize methods
     // in sequence.
     
-    if ($this->agentCollection instanceof AgentCollectionInterface) {
+    if (isset($this->agentCollection)) {
       foreach ($this->agentCollection as $agent) {
         $agent->initialize();
       }
@@ -285,11 +288,14 @@ abstract class AbstractHandler implements HandlerInterface
    * @return string
    * @throws HandlerException
    */
-  protected function addAction(string $hook, $callback, int $priority = 10, int $arguments = 1): string
-  {
-    if (!$this->isValidCallback($callback)) {
+  protected function addAction(string         $hook,
+                               string|Closure $callback,
+                               int            $priority = 10,
+                               int            $arguments = 1
+  ): string {
+    if (!$this->isValidCallback($callback, $arguments)) {
       throw new HandlerException(
-        $this->getInvalidCallbackMessage($callback),
+        'Callback expects more arguments than ' . $arguments . '.',
         HandlerException::INVALID_CALLBACK
       );
     }
@@ -308,72 +314,101 @@ abstract class AbstractHandler implements HandlerInterface
   /**
    * isValidCallback
    *
-   * Given a callback, returns true if it's valid, false otherwise.
+   * Given a callback, returns true if it's callable and if the number
+   * of arguments we're going to pass it is greater than or equal to the
+   * number of its required parameters.
    *
    * @param string|Closure $callback
+   * @param int            $arguments
    *
    * @return bool
+   * @throws HandlerException
    */
-  protected function isValidCallback($callback): bool
+  protected function isValidCallback(string|Closure $callback, int $arguments): bool
   {
-    // if $callback is a Closure, we're fine.  it's the string case that's
-    // more difficult so we'll bug out before worrying about anything else
-    // here.
-    
-    if ($callback instanceof Closure) {
-      return true;
+    try {
+      // note: the getReflectionMethod may through a HandlerException if the
+      // $callback either doesn't exist or is a private method.  we catch that
+      // exception in the calling scope.  the ReflectionFunction constructor
+      // can throw a ReflectionException; we catch that one here and re-throw
+      // our own.
+      
+      $reflection = !($callback instanceof Closure)
+        ? $this->getReflectionMethod($callback)
+        : new ReflectionFunction($callback);
+      
+      // now that we've reflected either the $callback Closure or a method of
+      // this object, we need to confirm that $arguments is greater than or
+      // equal to the number of required parameters.  it's okay to exceed the
+      // requirement because we assume that means a dev wants to override a
+      // default value.
+      
+      return $arguments >= $reflection->getNumberOfRequiredParameters();
+    } catch (ReflectionException $e) {
+      
+      // if we're here, the exception must have been thrown from within the
+      // ReflectionFunction constructor.  any other ReflectionException is
+      // caught and "converted" into our own HandlerException.  these are
+      // caught elsewhere.
+      
+      throw new HandlerException(
+        'Invalid callback.',
+        HandlerException::INVALID_CALLBACK,
+        $e
+      );
     }
-    
-    // now, if we're here, then $callback better be a string and, if so, it
-    // also has to be a non-private method of this object.  we can use our
-    // reflection to handle these tests.
+  }
+  
+  /**
+   * getReflectionMethod
+   *
+   * Returns a ReflectionMethod object for a non-private method within
+   * this object or throws an exception if the method doesn't exist or
+   * is private.
+   *
+   * @param string $callback
+   *
+   * @return ReflectionMethod
+   * @throws HandlerException
+   */
+  private function getReflectionMethod(string $callback): ReflectionMethod
+  {
+    // to try and save a bit of time, just in case this callback was already
+    // reflected, we've stored previously instantiated objects in memory.  if
+    // it's not already there, then we'll create it within the if-block and
+    // return it thereafter.
     
     try {
       if (!isset($this->reflectionMethods[$callback])) {
         $this->reflectionMethods[$callback] = $this->handlerReflection->getMethod($callback);
       }
       
-      return !$this->reflectionMethods[$callback]->isPrivate();
+      // now that we know our ReflectionMethod is found within our property,
+      // we'll see if it's private.  if it is, we throw a HandlerException
+      // which will be handled elsewhere regarding that fact.
+      
+      if ($this->reflectionMethods[$callback]->isPrivate()) {
+        throw new HandlerException(
+          'Invalid callback: ' . $callback . ' is private.',
+          HandlerException::INVALID_CALLBACK,
+        );
+      }
+      
     } catch (ReflectionException $e) {
       
-      // the getMethod method throws an exception when the requested
-      // method doesn't exist.  if it doesn't exist, then it can't be a
-      // callback, so we can just return false here.
+      // if we catch a ReflectionException, it will have been through from
+      // within the getMethod call above.  this indicates that $callback is not
+      // a method of our object, and we'll tell the calling scope about that
+      // fact by re-throwing one of our own exceptions here.
       
-      return false;
-    }
-  }
-  
-  /**
-   * getInvalidCallbackMessage
-   *
-   * Returns an exception message based on the type of $callback.
-   *
-   * @param string|object $callback
-   *
-   * @return string
-   */
-  private function getInvalidCallbackMessage($callback): string
-  {
-    // like the isValidCallback method above, this one uses the type of
-    // $callback to return an exception message about it's invalidity.
-    
-    if (is_string($callback)) {
-      
-      // if it's a string, then either (a) it wasn't a method of our
-      // object or (b) it was private.  we'll return a message based on
-      // which it was here.
-      
-      return $this->handlerReflection->hasMethod($callback)
-        ? $callback . ' must be public or protected'
-        : 'Method not found: ' . $callback;
+      throw new HandlerException(
+        'Invalid callback: unknown method, ' . $callback . '.',
+        HandlerException::INVALID_CALLBACK,
+        $e
+      );
     }
     
-    // if $callback wasn't a string, it must be an object, but that object
-    // must not have been a Closure or it would have been valid.  so, we'll
-    // simply request a method or Closure here.
-    
-    return 'Callbacks must be a handler method or Closure';
+    return $this->reflectionMethods[$callback];
   }
   
   /**
@@ -389,8 +424,11 @@ abstract class AbstractHandler implements HandlerInterface
    * @return void
    * @throws HandlerException
    */
-  private function addHookToCollection(string $hook, $callback, int $priority, int $arguments): void
-  {
+  private function addHookToCollection(string         $hook,
+                                       string|Closure $callback,
+                                       int            $priority,
+                                       int            $arguments
+  ): void {
     try {
       // to add a hook to our collection, we need the index it'll use therein
       // and the actually HookInterface implementation that we store.  we make
@@ -461,11 +499,14 @@ abstract class AbstractHandler implements HandlerInterface
    * @return string
    * @throws HandlerException
    */
-  protected function addFilter(string $hook, $callback, int $priority = 10, int $arguments = 1): string
-  {
-    if (!$this->isValidCallback($callback)) {
+  protected function addFilter(string         $hook,
+                               string|Closure $callback,
+                               int            $priority = 10,
+                               int            $arguments = 1
+  ): string {
+    if (!$this->isValidCallback($callback, $arguments)) {
       throw new HandlerException(
-        $this->getInvalidCallbackMessage($callback),
+        'Callback expects more arguments than ' . $arguments . '.',
         HandlerException::INVALID_CALLBACK
       );
     }


### PR DESCRIPTION
Too many times, I've used `addAction` or `addFilter` for a function that needs two or more arguments passed into its scope and forgotten to tell WordPress about that requirement.  So, I've modified the `isValidCallback` method to do so.  It will now indicate that a callback is invalid if the number of required parameters for a callback is less than the number of arguments WordPress is going to send it.